### PR TITLE
chore: remove model selection from workflow dispatch and action inputs

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -34,18 +34,6 @@ on:
         description: 'Tool config (e.g., strands_tools:shell;strands_coder:use_github)'
         required: false
         type: string
-      provider:
-        description: 'Model provider (empty = use repo vars or bedrock default)'
-        required: false
-        type: string
-      model:
-        description: 'Model ID (empty = use repo vars [Claude Opus 4.6 with adaptive thinking and 1M context])'
-        required: false
-        type: string
-      max_tokens:
-        description: 'Max tokens (empty = use repo vars [128000])'
-        required: false
-        type: string
 
 permissions: write-all
 
@@ -53,8 +41,8 @@ jobs:
   agent:
     runs-on: ubuntu-latest
     # Model config from repository variables — the single source of truth.
-    # Workflow dispatch inputs override these only when explicitly provided.
-    # If vars aren't set either, create_model() uses sensible per-provider defaults.
+    # Provider, model ID, and max tokens are ALL controlled via repo vars.
+    # No workflow-level overrides. Change vars.* to change the model.
     env:
       STRANDS_PROVIDER: ${{ vars.STRANDS_PROVIDER || 'bedrock' }}
       STRANDS_MODEL_ID: ${{ vars.STRANDS_MODEL_ID }}
@@ -174,13 +162,6 @@ jobs:
               (github.event_name == 'schedule' && 'I am running on a scheduled basis (every 4 hours). I will check the repository status, review open issues and PRs, and provide insights or suggestions for improvements, work on active tracked tasks and discover new opportunities to work on. I have full GitHub context available.') ||
               'I received a GitHub event and am running autonomously. I will analyze the context and take appropriate action. I have full GitHub event details available.'
             }}
-
-          # Model configuration — only pass workflow_dispatch inputs (override env vars).
-          # If not dispatched with explicit values, action.yml sees empty → env vars from
-          # this workflow's env block (set from vars.*) flow through untouched.
-          provider: ${{ github.event.inputs.provider || '' }}
-          model: ${{ github.event.inputs.model || '' }}
-          max_tokens: ${{ github.event.inputs.max_tokens || '' }}
 
           # System prompt configuration
           system_prompt: ${{ github.event.inputs.system_prompt || vars.SYSTEM_PROMPT || vars.INPUT_SYSTEM_PROMPT || 'You are a restricted GitHub agent for this repository, powered by Strands Agents SDK. Only authorized users can trigger your execution.' }}

--- a/action.yml
+++ b/action.yml
@@ -11,16 +11,6 @@ inputs:
     description: 'Task for the AI agent to perform'
     required: true
   
-  provider:
-    description: 'AI provider (bedrock, github, openai, anthropic). If empty, uses STRANDS_PROVIDER env var or bedrock default.'
-    required: false
-    default: ''
-  
-  model:
-    description: 'Model ID. If empty, uses STRANDS_MODEL_ID env var or provider default.'
-    required: false
-    default: ''
-  
   tools:
     description: 'Tool config string (e.g., strands_tools:shell,file_read;strands_action:gist)'
     required: false
@@ -28,11 +18,6 @@ inputs:
   
   system_prompt:
     description: 'System prompt'
-    required: false
-    default: ''
-  
-  max_tokens:
-    description: 'Maximum tokens for model response. If empty, uses STRANDS_MAX_TOKENS env var or provider default.'
     required: false
     default: ''
   
@@ -98,7 +83,7 @@ runs:
         git config --global user.email "${{ inputs.git_user_email }}"
 
     - name: Configure AWS (Bedrock only)
-      if: (inputs.provider == 'bedrock' || inputs.provider == '') && inputs.aws_role_arn != ''
+      if: inputs.aws_role_arn != ''
       uses: aws-actions/configure-aws-credentials@v5
       with:
         role-to-assume: ${{ inputs.aws_role_arn }}
@@ -143,10 +128,8 @@ runs:
       working-directory: ${{ github.workspace }}
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
-        # Model config inputs stored as _INPUT vars — only applied if non-empty (see run script)
-        _PROVIDER_INPUT: ${{ inputs.provider }}
-        _MODEL_INPUT: ${{ inputs.model }}
-        _MAX_TOKENS_INPUT: ${{ inputs.max_tokens }}
+        # Model config comes entirely from env vars set by the calling workflow.
+        # STRANDS_PROVIDER, STRANDS_MODEL_ID, STRANDS_MAX_TOKENS flow through untouched.
         STRANDS_ADDITIONAL_REQUEST_FIELDS: ${{ inputs.additional_request_fields || env.STRANDS_ADDITIONAL_REQUEST_FIELDS }}
         STRANDS_TOOLS: ${{ inputs.tools || env.STRANDS_TOOLS }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}
@@ -155,14 +138,7 @@ runs:
         PYTHONPATH: ${{ github.action_path }}
         VIRTUAL_ENV: ${{ github.action_path }}/.venv
       run: |
-        # Only override model config env vars if explicitly provided via inputs.
-        # This allows the calling workflow's env block (from vars.*) to be the source of truth.
-        # If neither input nor env var is set, create_model() uses sensible per-provider defaults.
-        [ -n "$_PROVIDER_INPUT" ] && export STRANDS_PROVIDER="$_PROVIDER_INPUT"
-        [ -n "$_MODEL_INPUT" ] && export STRANDS_MODEL_ID="$_MODEL_INPUT"
-        [ -n "$_MAX_TOKENS_INPUT" ] && export STRANDS_MAX_TOKENS="$_MAX_TOKENS_INPUT"
-
-        echo "🔧 Model config: STRANDS_PROVIDER=${STRANDS_PROVIDER:-<env/default>} STRANDS_MODEL_ID=${STRANDS_MODEL_ID:-<env/default>} STRANDS_MAX_TOKENS=${STRANDS_MAX_TOKENS:-<env/default>}"
+        echo "🔧 Model config: STRANDS_PROVIDER=${STRANDS_PROVIDER:-<default>} STRANDS_MODEL_ID=${STRANDS_MODEL_ID:-<default>} STRANDS_MAX_TOKENS=${STRANDS_MAX_TOKENS:-<default>}"
 
         if [ -f "${{ github.action_path }}/custom_agent_runner.py" ]; then
           "${{ github.action_path }}/.venv/bin/python" "${{ github.action_path }}/custom_agent_runner.py"


### PR DESCRIPTION
## What changed

Removed `provider`, `model`, and `max_tokens` inputs from both `agent.yml` workflow dispatch and `action.yml` composite action.

## Why

Model configuration should be controlled exclusively via repository variables (`vars.STRANDS_PROVIDER`, `vars.STRANDS_MODEL_ID`, `vars.STRANDS_MAX_TOKENS`). Per-dispatch model overrides caused confusion and failures when sub-agents were dispatched with model params that didn't match the repo's configuration.

## What's removed

**`agent.yml`:**
- `provider` input from `workflow_dispatch`
- `model` input from `workflow_dispatch`  
- `max_tokens` input from `workflow_dispatch`
- Model override passthrough in the `with:` block

**`action.yml`:**
- `provider` input
- `model` input
- `max_tokens` input
- `_INPUT` env var passthrough logic in the run step
- Provider-conditional AWS config (`inputs.provider == 'bedrock'` → just check `aws_role_arn`)

## How model config works now

```
vars.STRANDS_PROVIDER → env.STRANDS_PROVIDER → create_model()
vars.STRANDS_MODEL_ID → env.STRANDS_MODEL_ID → create_model()
vars.STRANDS_MAX_TOKENS → env.STRANDS_MAX_TOKENS → create_model()
```

Single source of truth. Change the repo vars to change the model. No per-dispatch overrides.

Related to #23